### PR TITLE
Updates for asset loading and draw on update

### DIFF
--- a/src/scripts/kingdom-info-layer.mjs
+++ b/src/scripts/kingdom-info-layer.mjs
@@ -14,31 +14,8 @@ export default class KingdomInfoLayer extends PIXI.Container {
   /**
    *  load textures for the KingdomInfoLayer
    */
-  async loadTextures() {
-    PIXI.Assets.addBundle("kingdom-info-layer", [
-      { alias: "recon", src: "modules/pf2e-kingdom-map-enhancement/assets/img/recon.png" },
-      { alias: "camp_quarry", src: "modules/pf2e-kingdom-map-enhancement/assets/img/quarry.png" },
-      { alias: "camp_lumber", src: "modules/pf2e-kingdom-map-enhancement/assets/img/lumbercamp.png" },
-      { alias: "camp_mine", src: "modules/pf2e-kingdom-map-enhancement/assets/img/mine.png" },
-      { alias: "res_ore", src: "modules/pf2e-kingdom-map-enhancement/assets/img/ore.png" },
-      { alias: "res_food", src: "modules/pf2e-kingdom-map-enhancement/assets/img/wheat.png" },
-      { alias: "res_lumber", src: "modules/pf2e-kingdom-map-enhancement/assets/img/lumber.png" },
-      { alias: "res_stone", src: "modules/pf2e-kingdom-map-enhancement/assets/img/stone.png" },
-      { alias: "res_luxuries", src: "modules/pf2e-kingdom-map-enhancement/assets/img/luxuries.png" },
-      { alias: "feat_farm", src: "modules/pf2e-kingdom-map-enhancement/assets/img/farmer.png" },
-      { alias: "feat_landmark", src: "modules/pf2e-kingdom-map-enhancement/assets/img/landmark.png" },
-      { alias: "feat_refuge", src: "modules/pf2e-kingdom-map-enhancement/assets/img/refuge.png" },
-      { alias: "feat_ruin", src: "modules/pf2e-kingdom-map-enhancement/assets/img/ruin.png" },
-      { alias: "feat_ford", src: "modules/pf2e-kingdom-map-enhancement/assets/img/ford.png" },
-      { alias: "feat_waterfall", src: "modules/pf2e-kingdom-map-enhancement/assets/img/waterfall.png" },
-      { alias: "feat_hazard", src: "modules/pf2e-kingdom-map-enhancement/assets/img/hazard.png" },
-      { alias: "feat_bloom", src: "modules/pf2e-kingdom-map-enhancement/assets/img/bloom.png" },
-      { alias: "feat_structure", src: "modules/pf2e-kingdom-map-enhancement/assets/img/structure.png" },
-      { alias: "feat_road", src: "modules/pf2e-kingdom-map-enhancement/assets/img/road.png" },
-      { alias: "feat_bridge", src: "modules/pf2e-kingdom-map-enhancement/assets/img/bridge.png" },
-      { alias: "feat_town", src: "modules/pf2e-kingdom-map-enhancement/assets/img/town.png" },
-    ]);
-    this.assets = await PIXI.Assets.loadBundle("kingdom-info-layer");
+  loadAssets(assets) {
+    this.assets = assets;
   }
 
   /**
@@ -49,10 +26,9 @@ export default class KingdomInfoLayer extends PIXI.Container {
     this.mask = canvas.primary.mask;
 
     const icon_size = 36;
-    const scalefactor = icon_size / 512
+    const scalefactor = icon_size / 512 //really need to replace this so we dont assume 512x512 icons
     const icon_pad = 10
     const hexes = kingmaker.region.hexes.filter(h => h.data.exploration == 1);
-    // const hexes_features = explored_hexes.filter( h => h.data.camp != "" || h.data.features.some(f => f.type == "farmland"));
     for ( const hex of hexes ) {
       const {x, y} = hex.center;
       const tx = hex.topLeft.x;
@@ -65,6 +41,7 @@ export default class KingdomInfoLayer extends PIXI.Container {
       reconimg.scale.set(scalefactor, scalefactor);
 
       if (hex.data.showResources == true) {
+        
         // if camp is defined, add camp icon
         if (hex.data.camp != "") {
           // Add work camp icons
@@ -79,6 +56,7 @@ export default class KingdomInfoLayer extends PIXI.Container {
           campimg.anchor.set(0.5, 0.5);
           campimg.position.set(x + (x - tx) / 2, (ty + (y - ty) / 2));
           campimg.scale.set(scalefactor, scalefactor);
+
         }
 
         if (hex.data.commodity != "") {
@@ -94,57 +72,61 @@ export default class KingdomInfoLayer extends PIXI.Container {
           } else if (hex.data.commodity == "luxuries") {
             var restex = this.assets["res_luxuries"];
           }
+
           const resimg = this.addChild(new PIXI.Sprite(restex));
           resimg.anchor.set(0.5, 0.5);
           resimg.position.set(tx + (x - tx) / 2, (ty + (y - ty) / 2));
           resimg.scale.set(scalefactor, scalefactor);
+
         }
       }
 
       // Add feature icons
-      if (hex.data.features.length > 0) {
-        // get how many features are in the hex
-        const num_features = hex.data.features.length;
+      var features = hex.data.features.filter(f => f.discovered == true);
+      if (features.length > 0) {
+
         const icons_per_row = 6;
-        const featlist_x = x - ((Math.min(num_features-1, icons_per_row-1 )*(icon_size + icon_pad)) / 2);
+        const featlist_x = x - ((Math.min(features.length-1, icons_per_row-1 )*(icon_size + icon_pad)) / 2);
         const featlist_y = y + (y - ty) / 3;
+
         // for each feature in the hex, add the icon
-        for (let i = 0; i < num_features; i++) {
-          if (hex.data.features[i].discovered == true) {
-            var feat_x = featlist_x + ((i % icons_per_row) * (icon_size + icon_pad));
-            var feat_y = featlist_y - (Math.floor(i / icons_per_row) * (icon_size + icon_pad));
-            if (hex.data.features[i].type == "farmland") {
-              var featex = this.assets["feat_farm"];
-            } else if (hex.data.features[i].type == "landmark") {
-              var featex = this.assets["feat_landmark"];
-            } else if (hex.data.features[i].type == "refuge") {
-              var featex = this.assets["feat_refuge"];
-            } else if (hex.data.features[i].type == "structure") {
-              var featex = this.assets["feat_structure"];
-            } else if (hex.data.features[i].type == "road") {
-              var featex = this.assets["feat_roadm"];
-            } else if (hex.data.features[i].type == "bridge") {
-              var featex = this.assets["feat_bridge"];
-            } else if (hex.data.features[i].type == "ruin") {
-              var featex = this.assets["feat_ruin"];
-            } else if (hex.data.features[i].type == "hazard") {
-              var featex = this.assets["feat_hazard"];
-            } else if (hex.data.features[i].type == "bloom") {
-              var featex = this.assets["feat_bloom"];
-            } else if (hex.data.features[i].type == "ford") {
-              var featex = this.assets["feat_ford"];
-            } else if (hex.data.features[i].type == "waterfall") {
-              var featex = this.assets["feat_waterfall"];
-            } else if (hex.data.features[i].type == "freehold" || hex.data.features[i].type == "village"|| hex.data.features[i].type == "town" || hex.data.features[i].type == "city" || hex.data.features[i].type == "metropolis") {
-              var featex = this.assets["feat_town"];
-            } else {
-              continue;
-            }
-            const featimg = this.addChild(new PIXI.Sprite(featex));
-            featimg.anchor.set(0.5, 0.5);
-            featimg.position.set(feat_x, feat_y);
-            featimg.scale.set(scalefactor, scalefactor);
+        for (let i = 0; i < features.length; i++) {
+
+          var feat_x = featlist_x + ((i % icons_per_row) * (icon_size + icon_pad));
+          var feat_y = featlist_y - (Math.floor(i / icons_per_row) * (icon_size + icon_pad));
+
+          if (features[i].type == "farmland") {
+            var featex = this.assets["feat_farm"];
+          } else if (features[i].type == "landmark") {
+            var featex = this.assets["feat_landmark"];
+          } else if (features[i].type == "refuge") {
+            var featex = this.assets["feat_refuge"];
+          } else if (features[i].type == "structure") {
+            var featex = this.assets["feat_structure"];
+          } else if (features[i].type == "road") {
+            var featex = this.assets["feat_roadm"];
+          } else if (features[i].type == "bridge") {
+            var featex = this.assets["feat_bridge"];
+          } else if (features[i].type == "ruin") {
+            var featex = this.assets["feat_ruin"];
+          } else if (features[i].type == "hazard") {
+            var featex = this.assets["feat_hazard"];
+          } else if (features[i].type == "bloom") {
+            var featex = this.assets["feat_bloom"];
+          } else if (features[i].type == "ford") {
+            var featex = this.assets["feat_ford"];
+          } else if (features[i].type == "waterfall") {
+            var featex = this.assets["feat_waterfall"];
+          } else if (features[i].type == "freehold" || features[i].type == "village"|| features[i].type == "town" || features[i].type == "city" || features[i].type == "metropolis") {
+            var featex = this.assets["feat_town"];
+          } else {
+            continue;
           }
+          
+          const featimg = this.addChild(new PIXI.Sprite(featex));
+          featimg.anchor.set(0.5, 0.5);
+          featimg.position.set(feat_x, feat_y);
+          featimg.scale.set(scalefactor, scalefactor);
         }
       }
 

--- a/src/scripts/kingdom-info-map.mjs
+++ b/src/scripts/kingdom-info-map.mjs
@@ -30,18 +30,40 @@ export default class KingdomInfoMap {
     return kingmaker.region.active;
   }
 
-  /* -------------------------------------------- */
-  /*  Canvas Lifecycle Hooks                      */
-  /* -------------------------------------------- */
-
   /**
-   * Canvas configuration.
-   * @internal
+   * The asset bundle for the KingdomInfoLayer
    */
-  _onConfig() {
-    if ( !this.active ) return;
+  assets;
+
+  async loadTextures() {
+    PIXI.Assets.addBundle("kingdom-info-layer", [
+      { alias: "recon", src: "modules/pf2e-kingdom-map-enhancement/assets/img/recon.png" },
+      { alias: "camp_quarry", src: "modules/pf2e-kingdom-map-enhancement/assets/img/quarry.png" },
+      { alias: "camp_lumber", src: "modules/pf2e-kingdom-map-enhancement/assets/img/lumbercamp.png" },
+      { alias: "camp_mine", src: "modules/pf2e-kingdom-map-enhancement/assets/img/mine.png" },
+      { alias: "res_ore", src: "modules/pf2e-kingdom-map-enhancement/assets/img/ore.png" },
+      { alias: "res_food", src: "modules/pf2e-kingdom-map-enhancement/assets/img/wheat.png" },
+      { alias: "res_lumber", src: "modules/pf2e-kingdom-map-enhancement/assets/img/lumber.png" },
+      { alias: "res_stone", src: "modules/pf2e-kingdom-map-enhancement/assets/img/stone.png" },
+      { alias: "res_luxuries", src: "modules/pf2e-kingdom-map-enhancement/assets/img/luxuries.png" },
+      { alias: "feat_farm", src: "modules/pf2e-kingdom-map-enhancement/assets/img/farmer.png" },
+      { alias: "feat_landmark", src: "modules/pf2e-kingdom-map-enhancement/assets/img/landmark.png" },
+      { alias: "feat_refuge", src: "modules/pf2e-kingdom-map-enhancement/assets/img/refuge.png" },
+      { alias: "feat_ruin", src: "modules/pf2e-kingdom-map-enhancement/assets/img/ruin.png" },
+      { alias: "feat_ford", src: "modules/pf2e-kingdom-map-enhancement/assets/img/ford.png" },
+      { alias: "feat_waterfall", src: "modules/pf2e-kingdom-map-enhancement/assets/img/waterfall.png" },
+      { alias: "feat_hazard", src: "modules/pf2e-kingdom-map-enhancement/assets/img/hazard.png" },
+      { alias: "feat_bloom", src: "modules/pf2e-kingdom-map-enhancement/assets/img/bloom.png" },
+      { alias: "feat_structure", src: "modules/pf2e-kingdom-map-enhancement/assets/img/structure.png" },
+      { alias: "feat_road", src: "modules/pf2e-kingdom-map-enhancement/assets/img/road.png" },
+      { alias: "feat_bridge", src: "modules/pf2e-kingdom-map-enhancement/assets/img/bridge.png" },
+      { alias: "feat_town", src: "modules/pf2e-kingdom-map-enhancement/assets/img/town.png" },
+    ]);
+    this.assets = await PIXI.Assets.loadBundle("kingdom-info-layer");
   }
 
+  /* -------------------------------------------- */
+  /*  Canvas Lifecycle Hooks                      */
   /* -------------------------------------------- */
 
   /**
@@ -52,7 +74,7 @@ export default class KingdomInfoMap {
     if ( !this.active ) return;
     if ( canvas.visibilityOptions ) canvas.visibilityOptions.persistentVision = true;
     this.kingdomInfoLayer = new KingdomInfoLayer();
-    this.kingdomInfoLayer.loadTextures();
+    this.kingdomInfoLayer.loadAssets(this.assets);
 
   }
 
@@ -64,6 +86,7 @@ export default class KingdomInfoMap {
    */
   _onDraw() {
     if ( !this.active ) return;
+    this.kingdomInfoLayer.draw();
   }
 
   /* -------------------------------------------- */
@@ -77,18 +100,6 @@ export default class KingdomInfoMap {
 
     // canvas.interface.grid.addChildAt(this.kingdomInfoLayer, canvas.interface.grid.children.indexOf(canvas.interface.grid.borders));
     canvas.interface.grid.addChild(this.kingdomInfoLayer);
-    this.kingdomInfoLayer.draw();
-
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Canvas tear-down.
-   * @internal
-   */
-  _onTearDown() {
-    if ( !this.active ) return;
 
   }
 
@@ -113,4 +124,9 @@ export default class KingdomInfoMap {
     };
     tokens.tools.push(this.#infoTool);
   };
+
+  _onUpdateSetting() {
+    if ( !this.active ) return;
+    this.kingdomInfoLayer.draw();
+  }
 }

--- a/src/scripts/kingdom-map-enhancement.mjs
+++ b/src/scripts/kingdom-map-enhancement.mjs
@@ -1,7 +1,7 @@
 import KingdomInfoMap from "./kingdom-info-map.mjs";
 
 /**
- * The ID of the Kingmaker module
+ * The ID of this module
  * @type {string}
  */
 const MODULE_ID = "pf2e-kingdom-map-enhancement";
@@ -12,7 +12,7 @@ const MODULE_ID = "pf2e-kingdom-map-enhancement";
 
 Hooks.once("init", function() {
     /**
-     * Global reference to the Kingmaker module.
+     * Global reference to this module.
      * @type {}
      */
     globalThis.kingdominfo = game.modules.get(MODULE_ID);
@@ -25,15 +25,20 @@ Hooks.once("init", function() {
 Hooks.once("setup", function() {
     console.log("Kingdom | Initializing Kingdom Map Enhancement");
     kingdominfo.kingdomInfoMap = new KingdomInfoMap();
+    kingdominfo.kingdomInfoMap.loadTextures();
 });
 
 /* -------------------------------------------- */
 /*  Canvas Events                               */
 /* -------------------------------------------- */
 
-Hooks.on("canvasConfig", () => kingdominfo.kingdomInfoMap._onConfig());
 Hooks.on("canvasInit", () => kingdominfo.kingdomInfoMap._onInit());
 Hooks.on("canvasDraw", () => kingdominfo.kingdomInfoMap._onDraw());
 Hooks.on("canvasReady", () => kingdominfo.kingdomInfoMap._onReady());
-Hooks.on("canvasTearDown", () => kingdominfo.kingdomInfoMap._onTearDown());
 Hooks.on("getSceneControlButtons", buttons => kingdominfo.kingdomInfoMap._extendSceneControlButtons(buttons));
+
+/* -------------------------------------------- */
+/*  JHook on updateSetting                      */
+/* -------------------------------------------- */
+
+Hooks.on("updateSetting", () => kingdominfo.kingdomInfoMap._onUpdateSetting());


### PR DESCRIPTION
- Moved asset loading to map class and performing it on setup, rather than on canvas load
- added hook on updateSetting so tokens get redrawn when updated.
- Fixed feature alignment so it only counts visible features.